### PR TITLE
Harden support log secret handling across copy, storage, and native logging

### DIFF
--- a/android/app/src/main/kotlin/com/secluso/mobile/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/secluso/mobile/MainActivity.kt
@@ -81,7 +81,6 @@ class MainActivity : FlutterActivity() {
                         Log.e("WIFI", "Found connectToWifi request");
                         val ssid = call.argument<String>("ssid")!!
                         val passphrase = call.argument<String>("password")!!
-                        Log.e("WIFI", "SSID = $ssid, passphrase = $passphrase")
 
                         try {
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/lib/routes/camera/list_cameras.dart
+++ b/lib/routes/camera/list_cameras.dart
@@ -542,7 +542,7 @@ class CamerasPageState extends State<CamerasPage>
   }
 
   Future<void> _copyLogs(BuildContext context) async {
-    final logs = await Log.getLogDump();
+    final logs = await Log.getCopySafeLogDump();
     final message =
         logs.trim().isEmpty
             ? 'No logs available yet.'
@@ -605,7 +605,11 @@ class CamerasPageState extends State<CamerasPage>
                 ),
                 TextButton(
                   onPressed: () async {
-                    await Clipboard.setData(ClipboardData(text: snapshot.logs));
+                    await Clipboard.setData(
+                      ClipboardData(
+                        text: Log.redactSecretsForCopy(snapshot.logs),
+                      ),
+                    );
                     await Log.clearBackgroundSnapshot();
                     await Log.clearErrorFlag();
                     if (mounted) {

--- a/lib/routes/camera/new/qr_scan.dart
+++ b/lib/routes/camera/new/qr_scan.dart
@@ -989,7 +989,6 @@ class _QrScanDialogState extends State<QrScanDialog>
     if (_hasScannedCode || !barcode.isValid) return; // already handled
 
     final text = barcode.text;
-    Log.d("Detected barcode with text: $text");
     if (text == null || text.isEmpty) {
       return;
     }

--- a/lib/routes/settings_page.dart
+++ b/lib/routes/settings_page.dart
@@ -226,7 +226,7 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   Future<void> _copyLogs() async {
-    final logs = await Log.getLogDump();
+    final logs = await Log.getCopySafeLogDump();
     final exportText = logs.trim().isEmpty ? 'No logs available yet.' : logs;
     await Clipboard.setData(ClipboardData(text: exportText));
     if (!mounted) return;

--- a/lib/utilities/http_client.dart
+++ b/lib/utilities/http_client.dart
@@ -128,7 +128,6 @@ class HttpClientService {
   static const int maxFcmConfigSize = 10 * 1024; // 10 kibibytes
   static const int maxServerVersionSize = 10 * 1024; // 10 kibibytes
 
-
   HttpClientService._();
   static final HttpClientService instance = HttpClientService._();
   Future<void>? _versionCheckInFlight;
@@ -400,8 +399,7 @@ class HttpClientService {
       }
     }
 
-    print(response.body);
-    Log.d("Success fetching fcm config");
+    Log.d("Success fetching fcm config (bytes=${response.body.length})");
     return FcmConfig.fromJson(jsonDecode(response.body));
   }, bypassVersionGate: true);
 

--- a/lib/utilities/logger.dart
+++ b/lib/utilities/logger.dart
@@ -34,6 +34,8 @@ class Log {
   static const String _prefsBackgroundReasonKey = 'log_background_reason';
   static const String _prefsBackgroundTsKey = 'log_background_ts';
   static const String _copyRedactionPlaceholder = 'SECRET HIDDEN';
+  static const String _copySecretValuePattern =
+      "(?:\"[^\"\\n]*\"|'[^'\\n]*'|[^,\\n)\\]}]+)";
 
   static final ValueNotifier<int> errorNotifier = ValueNotifier(0);
 
@@ -41,11 +43,15 @@ class Log {
   static String _defaultContext = '';
   static final List<RegExp> _copySecretPatterns = [
     RegExp(
-      "((?:password|passphrase|secret|token|authorization)\\s*[:=]\\s*)(?:\"[^\"\\n]*\"|'[^'\\n]*'|[^,\\n)\\]}]+)",
+      "((?:password|passphrase|secret|token|authorization|auth)\\s*[:=]\\s*)($_copySecretValuePattern)",
       caseSensitive: false,
     ),
     RegExp(
-      "((?:password|passphrase|secret|token|authorization)\\s+to\\s+)(?:\"[^\"\\n]*\"|'[^'\\n]*'|[^,\\n)\\]}]+)",
+      "((?:password|passphrase|secret|token|authorization|auth)\\s+to\\s+)($_copySecretValuePattern)",
+      caseSensitive: false,
+    ),
+    RegExp(
+      "((?:\"|')?[A-Za-z0-9_-]*?(?:password|passphrase|secret|token|authorization|auth)[A-Za-z0-9_-]*?(?:\"|')?\\s*[:=]\\s*)($_copySecretValuePattern)",
       caseSensitive: false,
     ),
   ];
@@ -193,7 +199,15 @@ class Log {
     for (final pattern in _copySecretPatterns) {
       redacted = redacted.replaceAllMapped(pattern, (match) {
         final prefix = match.group(1) ?? '';
-        return '$prefix$_copyRedactionPlaceholder';
+        final value = match.group(2) ?? '';
+        final replacementValue = switch (value) {
+          final quoted when quoted.startsWith('"') && quoted.endsWith('"') =>
+            '"$_copyRedactionPlaceholder"',
+          final quoted when quoted.startsWith("'") && quoted.endsWith("'") =>
+            "'$_copyRedactionPlaceholder'",
+          _ => _copyRedactionPlaceholder,
+        };
+        return '$prefix$replacementValue';
       });
     }
     return redacted;

--- a/lib/utilities/logger.dart
+++ b/lib/utilities/logger.dart
@@ -169,9 +169,14 @@ class Log {
       final prefs = await SharedPreferences.getInstance();
       final stored = prefs.getStringList(_prefsKey);
       if (stored != null && stored.isNotEmpty) {
-        _buffer = List<String>.from(stored);
+        final sanitized = _sanitizeBufferedLines(stored);
+        final changed = !_listEquals(stored, sanitized);
+        _buffer = List<String>.from(sanitized);
         if (_buffer.length > _maxEntries) {
           _buffer = _buffer.sublist(_buffer.length - _maxEntries);
+        }
+        if (changed) {
+          _scheduleFlush();
         }
       }
       _lastErrorEpochMs = prefs.getInt(_prefsErrorKey) ?? 0;
@@ -241,7 +246,11 @@ class Log {
         ts == null
             ? null
             : DateTime.fromMillisecondsSinceEpoch(ts, isUtc: false);
-    return BackgroundLogSnapshot(data, reason: reason, timestamp: when);
+    return BackgroundLogSnapshot(
+      redactSecretsForCopy(data),
+      reason: reason,
+      timestamp: when,
+    );
   }
 
   static Future<void> clearBackgroundSnapshot() async {
@@ -372,10 +381,26 @@ class Log {
   }
 
   static void _appendLine(String line) {
-    _buffer.add(line);
+    _buffer.add(_sanitizeLineForStorage(line));
     if (_buffer.length > _maxEntries) {
       _buffer.removeRange(0, _buffer.length - _maxEntries);
     }
+  }
+
+  static String _sanitizeLineForStorage(String line) {
+    return redactSecretsForCopy(line);
+  }
+
+  static List<String> _sanitizeBufferedLines(List<String> lines) {
+    return lines.map(_sanitizeLineForStorage).toList(growable: false);
+  }
+
+  static bool _listEquals(List<String> left, List<String> right) {
+    if (left.length != right.length) return false;
+    for (var i = 0; i < left.length; i++) {
+      if (left[i] != right[i]) return false;
+    }
+    return true;
   }
 
   static String _formatLine(

--- a/lib/utilities/logger.dart
+++ b/lib/utilities/logger.dart
@@ -43,10 +43,6 @@ class Log {
   static String _defaultContext = '';
   static final List<RegExp> _copySecretPatterns = [
     RegExp(
-      "((?:password|passphrase|secret|token|authorization|auth)\\s*[:=]\\s*)($_copySecretValuePattern)",
-      caseSensitive: false,
-    ),
-    RegExp(
       "((?:password|passphrase|secret|token|authorization|auth)\\s+to\\s+)($_copySecretValuePattern)",
       caseSensitive: false,
     ),

--- a/lib/utilities/logger.dart
+++ b/lib/utilities/logger.dart
@@ -33,11 +33,22 @@ class Log {
   static const String _prefsBackgroundKey = 'log_background_snapshot';
   static const String _prefsBackgroundReasonKey = 'log_background_reason';
   static const String _prefsBackgroundTsKey = 'log_background_ts';
+  static const String _copyRedactionPlaceholder = 'SECRET HIDDEN';
 
   static final ValueNotifier<int> errorNotifier = ValueNotifier(0);
 
   static final Object _contextKey = Object();
   static String _defaultContext = '';
+  static final List<RegExp> _copySecretPatterns = [
+    RegExp(
+      "((?:password|passphrase|secret|token|authorization)\\s*[:=]\\s*)(?:\"[^\"\\n]*\"|'[^'\\n]*'|[^,\\n)\\]}]+)",
+      caseSensitive: false,
+    ),
+    RegExp(
+      "((?:password|passphrase|secret|token|authorization)\\s+to\\s+)(?:\"[^\"\\n]*\"|'[^'\\n]*'|[^,\\n)\\]}]+)",
+      caseSensitive: false,
+    ),
+  ];
 
   static void init() {
     _logger = _buildLogger();
@@ -170,6 +181,22 @@ class Log {
   static Future<String> getLogDump() async {
     await ensureStorageReady();
     return _buffer.join('\n');
+  }
+
+  static Future<String> getCopySafeLogDump() async {
+    final logs = await getLogDump();
+    return redactSecretsForCopy(logs);
+  }
+
+  static String redactSecretsForCopy(String text) {
+    var redacted = text;
+    for (final pattern in _copySecretPatterns) {
+      redacted = redacted.replaceAllMapped(pattern, (match) {
+        final prefix = match.group(1) ?? '';
+        return '$prefix$_copyRedactionPlaceholder';
+      });
+    }
+    return redacted;
   }
 
   static Future<void> saveBackgroundSnapshot({String reason = ''}) async {

--- a/test/logger_redaction_test.dart
+++ b/test/logger_redaction_test.dart
@@ -40,6 +40,18 @@ void main() {
     );
   });
 
+  test('redacts JSON-style secret keys in copied logs', () {
+    const input =
+        '12:00:00.000 [D] http_client.dart:1:1 -> Pairing body: {"pairing_token":"abc123","notification_target":{"ios_relay_binding":{"hub_token":"hub456","device_token":"dev789"},"unifiedpush_auth":"auth000"}}';
+
+    final redacted = Log.redactSecretsForCopy(input);
+
+    expect(
+      redacted,
+      '12:00:00.000 [D] http_client.dart:1:1 -> Pairing body: {"pairing_token":"SECRET HIDDEN","notification_target":{"ios_relay_binding":{"hub_token":"SECRET HIDDEN","device_token":"SECRET HIDDEN"},"unifiedpush_auth":"SECRET HIDDEN"}}',
+    );
+  });
+
   test('leaves non-secret log text unchanged', () {
     const input =
         '12:00:00.000 [I] scheduler.dart:1:1 -> Network statuses: wifi = true, cell = false';

--- a/test/logger_redaction_test.dart
+++ b/test/logger_redaction_test.dart
@@ -1,0 +1,51 @@
+//! SPDX-License-Identifier: GPL-3.0-or-later
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:secluso_flutter/utilities/logger.dart';
+
+void main() {
+  test('redacts assignment-style secrets in copied logs', () {
+    const input =
+        '12:00:00.000 [E] main.dart:1:1 -> passphrase = camera-pass, token: abc123';
+
+    final redacted = Log.redactSecretsForCopy(input);
+
+    expect(
+      redacted,
+      '12:00:00.000 [E] main.dart:1:1 -> passphrase = SECRET HIDDEN, token: SECRET HIDDEN',
+    );
+  });
+
+  test('redacts narrative token disclosures in copied logs', () {
+    const input =
+        '12:00:00.000 [D] firebase.dart:1:1 -> Set FCM token to xyz789';
+
+    final redacted = Log.redactSecretsForCopy(input);
+
+    expect(
+      redacted,
+      '12:00:00.000 [D] firebase.dart:1:1 -> Set FCM token to SECRET HIDDEN',
+    );
+  });
+
+  test('preserves surrounding punctuation when redacting', () {
+    const input =
+        '12:00:00.000 [D] relay.dart:1:1 -> Updated APNs token (token=abc123)';
+
+    final redacted = Log.redactSecretsForCopy(input);
+
+    expect(
+      redacted,
+      '12:00:00.000 [D] relay.dart:1:1 -> Updated APNs token (token=SECRET HIDDEN)',
+    );
+  });
+
+  test('leaves non-secret log text unchanged', () {
+    const input =
+        '12:00:00.000 [I] scheduler.dart:1:1 -> Network statuses: wifi = true, cell = false';
+
+    final redacted = Log.redactSecretsForCopy(input);
+
+    expect(redacted, input);
+  });
+}


### PR DESCRIPTION
This PR hardens how secret handling in app logs and support-log exports. 

1) Catch both non-JSON and JSON-style secret fields and redacting them in support log exports. Logs are sanitized before they hit the buffer.
2) Went through and ripped out a few spots where raw secrets were being logged in the first place: the Android hotspot passphrase was leaking into logcat, QR payloads were being logged raw, and the FCM config response body was getting printed out as-is. All of those are gone now.
