### PR TITLE
Normalize unsigned AAB output in Docker repro build

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -181,7 +181,7 @@ android {
         applicationId = "com.secluso.mobile"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        minSdk = 23
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -667,26 +667,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -723,26 +723,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1255,10 +1255,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.4"
   timezone:
     dependency: transitive
     description:
@@ -1391,10 +1391,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   video_player:
     dependency: "direct main"
     description:
@@ -1590,5 +1590,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.8.0 <4.0.0"
   flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+4
+version: 1.0.0+5
 
 environment:
   sdk: ^3.7.2

--- a/tool/repro/aab_normalize.py
+++ b/tool/repro/aab_normalize.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import pathlib
+import sys
+import zipfile
+
+
+FIXED_DT = (1980, 1, 1, 0, 0, 0)
+
+
+def normalize_archive(input_path: pathlib.Path, output_path: pathlib.Path) -> None:
+    with zipfile.ZipFile(input_path, "r") as src, zipfile.ZipFile(
+        output_path,
+        "w",
+        compression=zipfile.ZIP_DEFLATED,
+        compresslevel=9,
+        allowZip64=True,
+    ) as dst:
+        dst.comment = b""
+        for name in sorted(info.filename for info in src.infolist() if not info.is_dir()):
+            data = src.read(name)
+            info = zipfile.ZipInfo(filename=name, date_time=FIXED_DT)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.create_system = 0
+            info.create_version = 20
+            info.extract_version = 20
+            info.flag_bits = 0
+            info.volume = 0
+            info.internal_attr = 0
+            info.external_attr = 0
+            info.extra = b""
+            info.comment = b""
+            dst.writestr(info, data)
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("Usage: aab_normalize.py <input.aab> <output.aab>", file=sys.stderr)
+        return 2
+
+    input_path = pathlib.Path(sys.argv[1]).resolve()
+    output_path = pathlib.Path(sys.argv[2]).resolve()
+
+    if not input_path.is_file():
+        print(f"Missing AAB archive: {input_path}", file=sys.stderr)
+        return 2
+    if input_path == output_path:
+        print("Input and output paths must differ.", file=sys.stderr)
+        return 2
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    normalize_archive(input_path, output_path)
+    print(output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tool/repro/build_aab_with_docker.sh
+++ b/tool/repro/build_aab_with_docker.sh
@@ -7,6 +7,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 DOCKER_PLATFORM="${SECLUSO_DOCKER_PLATFORM:-linux/amd64}"
 HOST_CACHE_ROOT="${SECLUSO_REPRO_CACHE_ROOT:-$REPO_ROOT/.secluso-repro-cache}"
 USE_HOST_CACHES="${SECLUSO_REPRO_USE_HOST_CACHES:-1}"
+AAB_PATH="$REPO_ROOT/build/reproducible/app-release-unsigned.aab"
+AAB_SHA_PATH="$AAB_PATH.sha256"
 
 dockerfile_hash() {
   if command -v sha256sum >/dev/null 2>&1; then
@@ -68,11 +70,20 @@ docker run --rm \
   /workspace/tool/repro/run_build_in_container_workspace.sh \
     tool/repro/build_unsigned_android_appbundle.sh
 
-if [[ -f "$REPO_ROOT/build/reproducible/app-release-unsigned.aab.sha256" ]]; then
-  tmp_sha="$(mktemp "${TMPDIR:-/tmp}/secluso-aab-sha.XXXXXX")"
-  sed "s|/workspace|$REPO_ROOT|g" \
-    "$REPO_ROOT/build/reproducible/app-release-unsigned.aab.sha256" > "$tmp_sha"
-  mv "$tmp_sha" "$REPO_ROOT/build/reproducible/app-release-unsigned.aab.sha256"
+if [[ -f "$AAB_PATH" ]]; then
+  tmp_aab="$(mktemp "${TMPDIR:-/tmp}/secluso-aab-normalized.XXXXXX.aab")"
+  python3 "$SCRIPT_DIR/aab_normalize.py" "$AAB_PATH" "$tmp_aab" >/dev/null
+  mv "$tmp_aab" "$AAB_PATH"
 fi
 
-printf '\n==> Host artifact ready at %s\n' "$REPO_ROOT/build/reproducible/app-release-unsigned.aab"
+if [[ -f "$AAB_SHA_PATH" ]]; then
+  tmp_sha="$(mktemp "${TMPDIR:-/tmp}/secluso-aab-sha.XXXXXX")"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$AAB_PATH" > "$tmp_sha"
+  else
+    shasum -a 256 "$AAB_PATH" > "$tmp_sha"
+  fi
+  mv "$tmp_sha" "$AAB_SHA_PATH"
+fi
+
+printf '\n==> Host artifact ready at %s\n' "$AAB_PATH"


### PR DESCRIPTION
This PR makes the Docker reproducible AAB build emit a canonical unsigned .aab on the host.

It adds an AAB normalization step after the container build completes and before the host checksum is written. The normalized artifact is then used as the final output in build/reproducible/app-release-unsigned.aab.

I found that two AABs built from the same branch but from different operating systems (Linux and MacOS) could have identical member payloads but still differ byte-for-byte because of ZIP container layout differences, specifically entry ordering within BUNDLE-METADATA/.../debugsymbols/...