### PR TITLE
Harden the logic to detect the offline state of a camera in order to avoid false reports.

### DIFF
--- a/lib/notifications/heartbeat_task.dart
+++ b/lib/notifications/heartbeat_task.dart
@@ -73,6 +73,7 @@ Future<bool> _doHeartbeatTask(String cameraName) async {
       final timestamp = BigInt.from(timestampInt);
       var successful = false;
       var downloaded = false;
+      var networkError = false;
       Log.d("$cameraName: Heartbeat timestamp = $timestamp");
 
       var lastHeartbeatTimestamp =
@@ -282,11 +283,15 @@ Future<bool> _doHeartbeatTask(String cameraName) async {
                 Log.d(
                   '$cameraName: Error fetching heartbeat config response (attempt $i): $err',
                 );
+                if (err is! SilentException) {
+                  Log.d('$cameraName: Non-404 error detected');
+                  networkError = true;
+                }
               },
             );
           }
 
-          if (downloaded && !successful) {
+          if (downloaded && !successful && !networkError) {
             // We get here if we could not successfully fetch the response in all the attempts in the loop
             // If we delete the camera while heartbeat is taking place, we could end up
             // here after the camera is deleted. So we check that here.

--- a/lib/routes/camera/view_camera.dart
+++ b/lib/routes/camera/view_camera.dart
@@ -99,6 +99,8 @@ class _CameraViewPageState extends State<CameraViewPage> with RouteAware {
   bool _downloadActive = false;
   bool get _isPreviewMode => widget.previewVideos != null;
 
+  int _cameraStatus = CameraStatus.online;
+
   Future<void> _openSettings() async {
     final action = await Navigator.push<CameraSettingsAction>(
       context,
@@ -224,9 +226,13 @@ class _CameraViewPageState extends State<CameraViewPage> with RouteAware {
     final prefs = await SharedPreferences.getInstance();
     await prefs.reload();
     final cameraName = widget.cameraName;
-    var cameraStatus =
-        prefs.getInt(PrefKeys.cameraStatusPrefix + cameraName) ??
-        CameraStatus.online;
+    final cameraStatus =
+      prefs.getInt(PrefKeys.cameraStatusPrefix + cameraName) ??
+      CameraStatus.online;
+
+    if (mounted) {
+      setState(() => _cameraStatus = cameraStatus);
+    }
     Log.d("Viewing camera: camera status = $cameraStatus");
 
     if (cameraStatus == CameraStatus.offline ||
@@ -1102,6 +1108,7 @@ class _CameraViewPageState extends State<CameraViewPage> with RouteAware {
   Widget _overviewHeader(_CameraViewMetrics metrics) {
     final theme = Theme.of(context);
     final dark = theme.brightness == Brightness.dark;
+    final isOnline = _cameraStatus == CameraStatus.online;
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -1130,14 +1137,14 @@ class _CameraViewPageState extends State<CameraViewPage> with RouteAware {
                   Container(
                     width: metrics.statusDotSize,
                     height: metrics.statusDotSize,
-                    decoration: const BoxDecoration(
-                      color: Color(0xFF10B981),
+                    decoration: BoxDecoration(
+                      color: isOnline ? const Color(0xFF10B981) : const Color(0xFFEF4444),
                       shape: BoxShape.circle,
                     ),
                   ),
                   SizedBox(width: metrics.statusDotGap),
                   Text(
-                    'ONLINE · E2E ENCRYPTED',
+                    isOnline ? 'ONLINE · E2E ENCRYPTED' : 'OFFLINE',
                     style: theme.textTheme.labelMedium?.copyWith(
                       color:
                           dark

--- a/lib/utilities/http_client.dart
+++ b/lib/utilities/http_client.dart
@@ -31,9 +31,9 @@ class DownloadResult {
   DownloadResult({this.not_found = false, this.file, this.data});
 }
 
-class _SilentException implements Exception {
+class SilentException implements Exception {
   final String message;
-  _SilentException(this.message);
+  SilentException(this.message);
   @override
   String toString() => message;
 }
@@ -389,7 +389,7 @@ class HttpClientService {
     await _handleServerVersionHeader(response);
     if (response.statusCode != 200) {
       if (response.statusCode == 404) {
-        throw _SilentException(
+        throw SilentException(
           'Failed to fetch fcm config: ${response.statusCode} ${response.reasonPhrase}',
         );
       } else {
@@ -495,7 +495,7 @@ class HttpClientService {
     await _handleServerVersionHeader(delResponse);
     if (delResponse.statusCode != 200) {
       if (delResponse.statusCode == 404) {
-        throw _SilentException(
+        throw SilentException(
           'Failed to delete video from server: ${delResponse.statusCode} ${delResponse.reasonPhrase}',
         );
       } else {
@@ -598,7 +598,7 @@ class HttpClientService {
           'Failed to fetch data: ${response.statusCode} ${response.reasonPhrase}';
       if (response.statusCode == 404) {
         // A missing next chunk is a normal livestream pause/end condition.
-        throw _SilentException(message);
+        throw SilentException(message);
       }
       throw Exception(message);
     }
@@ -635,23 +635,32 @@ class HttpClientService {
   /// POST /config/<group>
   Future<Result<void>> configCommand({
     required String cameraName,
-    required Object command,
+    required Uint8List command,
   }) => _wrap(() async {
     final creds = await _getValidatedCredentials();
     final group = await _groupName(cameraName, Group.config);
     final url = _buildUrl(creds.serverAddr, ['config', group]);
-    final headers = await _basicAuthHeaders(creds.username, creds.password);
 
-    final response = await http.post(url, headers: headers, body: command);
+    if (command.isEmpty) {
+      throw Exception('Error: empty config command');
+    }
+
+    final headers = await _basicAuthHeaders(creds.username, creds.password);
+    headers['X-Command-Size'] = command.length.toString();
+
+    final response = await http
+        .post(url, headers: headers, body: command);
+
     await _handleServerVersionHeader(response);
 
     if (response.statusCode != 200) {
       throw Exception(
-        'Failed to send config command: ${response.statusCode} ${response.reasonPhrase}',
+        'Failed to send config command: ${response.statusCode} '
+        '${response.reasonPhrase}: ${response.body}',
       );
-    } else {
-      Log.d("Successfully sent config command");
     }
+
+    Log.d("Successfully sent config command");
   });
 
   /// GET /config_response/<group>
@@ -672,7 +681,7 @@ class HttpClientService {
     await _handleServerVersionHeader(response);
     if (response.statusCode != 200) {
       if (response.statusCode == 404) {
-        throw _SilentException(
+        throw SilentException(
           'Failed to fetch config response: ${response.statusCode} ${response.reasonPhrase}',
         );
       } else {
@@ -699,8 +708,9 @@ class HttpClientService {
       }
       return Result.success(await block());
     } catch (e, st) {
-      if (e is _SilentException) {
+      if (e is SilentException) {
         Log.d("HttpClientService error: $e");
+        return Result.failure(e);
       } else if (_isNetworkException(e)) {
         Log.w("HttpClientService warning: $e");
       } else {
@@ -723,7 +733,7 @@ class HttpClientService {
   Future<void> _ensureVersionCompatible() async {
     if (VersionGate.isBlocked) {
       await potentiallySendBackgroundNotification();
-      throw _SilentException('Version gate active');
+      throw SilentException('Version gate active');
     }
     if (_versionMatchConfirmed) {
       return;
@@ -732,7 +742,7 @@ class HttpClientService {
     await _versionCheckInFlight;
     _versionCheckInFlight = null;
     if (VersionGate.isBlocked) {
-      throw _SilentException('Version gate active');
+      throw SilentException('Version gate active');
     }
   }
 
@@ -756,7 +766,7 @@ class HttpClientService {
       );
 
       await potentiallySendBackgroundNotification();
-      throw _SilentException('Server/client version mismatch');
+      throw SilentException('Server/client version mismatch');
     }
 
     _versionMatchConfirmed = true;
@@ -882,7 +892,7 @@ class HttpClientService {
       username?.trim(),
       password?.trim(),
     ].any((value) => value == null || value.isEmpty)) {
-      throw _SilentException('Missing server credentials');
+      throw SilentException('Missing server credentials');
     }
 
     return (
@@ -952,7 +962,7 @@ class HttpClientService {
     }
 
     if (groupName.startsWith("Error: Busy")) {
-      throw _SilentException('Group name busy for $cameraName ($clientTag)');
+      throw SilentException('Group name busy for $cameraName ($clientTag)');
     }
 
     Log.w(
@@ -964,7 +974,7 @@ class HttpClientService {
     final lastAttempt = _groupNameInitLast[retryKey];
     if (lastAttempt != null &&
         now.difference(lastAttempt) < _groupNameInitCooldown) {
-      throw _SilentException(
+      throw SilentException(
         'Group name unavailable for $cameraName ($clientTag)',
       );
     }
@@ -998,7 +1008,7 @@ class HttpClientService {
       );
     }
 
-    throw _SilentException(
+    throw SilentException(
       'Group name unavailable for $cameraName ($clientTag)',
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -667,26 +667,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -723,26 +723,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1255,10 +1255,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.10"
   timezone:
     dependency: transitive
     description:
@@ -1391,10 +1391,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   video_player:
     dependency: "direct main"
     description:
@@ -1590,5 +1590,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.32.0"


### PR DESCRIPTION
I observed some false "camera offline" notifications. Further investigations showed that they happened because the app could not sometimes fully upload the heartbeat config command to the server when in the background (in Android). This PR (along with one to be submitted to secluso/core for server) helps return an error when the upload is not complete.

The PR also proactively fixes another potential source of false reports and fixes the UI to correctly show the camera to be offline.