### PR TITLE
Handle dirty cache correctly

### DIFF
--- a/rust_builder/android/build.gradle
+++ b/rust_builder/android/build.gradle
@@ -1,6 +1,6 @@
 // The Android Gradle Plugin builds the native code with the Android NDK.
 
-group 'com.flutter_rust_bridge.rust_lib_privastead_flutter'
+group 'com.flutter_rust_bridge.rust_lib_secluso_flutter'
 version '1.0'
 
 buildscript {
@@ -26,7 +26,7 @@ apply plugin: 'com.android.library'
 
 android {
     if (project.android.hasProperty("namespace")) {
-        namespace 'com.flutter_rust_bridge.rust_lib_privastead_flutter'
+        namespace 'com.flutter_rust_bridge.rust_lib_secluso_flutter'
     }
 
     // Bumping the plugin compileSdkVersion requires all clients of this plugin
@@ -52,5 +52,5 @@ android {
 apply from: "../cargokit/gradle/plugin.gradle"
 cargokit {
     manifestDir = "../../rust"
-    libname = "rust_lib_privastead_flutter"
+    libname = "rust_lib_secluso_flutter"
 }

--- a/rust_builder/android/settings.gradle
+++ b/rust_builder/android/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'rust_lib_privastead_flutter'
+rootProject.name = 'rust_lib_secluso_flutter'

--- a/rust_builder/android/src/main/AndroidManifest.xml
+++ b/rust_builder/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.flutter_rust_bridge.rust_lib_privastead_flutter">
+  package="com.flutter_rust_bridge.rust_lib_secluso_flutter">
 </manifest>

--- a/tool/repro/README.md
+++ b/tool/repro/README.md
@@ -52,6 +52,18 @@ That builds the unsigned Android App Bundle in Docker and puts it here:
 build/reproducible/app-release-unsigned.aab
 ```
 
+Recommended safe reproducibility check
+
+When verifying reproducibility from a dirty local environment, use this command:
+
+```bash
+env SECLUSO_REPRO_CLEAN=1 SECLUSO_REPRO_USE_HOST_CACHES=0 SECLUSO_REPRO_GRADLE_JVMARGS='-Xmx2G -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError' tool/repro/build_aab_with_docker.sh
+```
+
+- SECLUSO_REPRO_CLEAN=1 removes the copied workspace's Flutter, Android, and Rust build outputs before building. 
+- SECLUSO_REPRO_USE_HOST_CACHES=0 avoids mounting the host Gradle and Dart package caches into the container
+- SECLUSO_REPRO_GRADLE_JVMARGS=.. caps the Gradle and Kotlin daemon heaps. On Docker Desktop, the default android/gradle.properties heap can reserve too much memory during the clean native build and the Gradle daemon may disappear. 
+
 The same F-Droid switch works for the App Bundle path:
 
 ```bash
@@ -144,7 +156,7 @@ build/reproducible/app-release-signed.aab
 build/reproducible/app-release-signed.aab.sha256
 ```
 
-One thing that might happen is that the build fails at flutter pub get --enforce-lockfile. If that happens, it means the committed pubspec.lock no longer matches what the pinned Docker toolchain resolves for the current pubspec.yaml. In that case, update the lockfile with:
+One thing that might happen is that the Docker build fails at flutter pub get --enforce-lockfile. If that happens, it means the committed pubspec.lock no longer matches what the pinned Docker toolchain resolves for the current pubspec.yaml. In that case, update the lockfile with:
 
 ```bash
 tool/repro/update_lockfile_with_docker.sh

--- a/tool/repro/build_aab_with_docker.sh
+++ b/tool/repro/build_aab_with_docker.sh
@@ -64,8 +64,12 @@ docker run --rm \
   --platform "$DOCKER_PLATFORM" \
   -e SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-1704067200}" \
   -e SECLUSO_FDROID_BUILD="${SECLUSO_FDROID_BUILD:-0}" \
+  -e SECLUSO_REPRO_CLEAN="${SECLUSO_REPRO_CLEAN:-0}" \
+  -e SECLUSO_REPRO_GRADLE_JVMARGS="${SECLUSO_REPRO_GRADLE_JVMARGS:-}" \
+  -e SECLUSO_REPRO_MAX_WORKERS="${SECLUSO_REPRO_MAX_WORKERS:-}" \
+  -e SECLUSO_REPRO_SYNC_BACK_FAST_CACHES="${SECLUSO_REPRO_SYNC_BACK_FAST_CACHES:-1}" \
   -v "$REPO_ROOT":/workspace \
-  "${DOCKER_CACHE_VOLUMES[@]}" \
+  ${DOCKER_CACHE_VOLUMES+"${DOCKER_CACHE_VOLUMES[@]}"} \
   "$IMAGE_TAG" \
   /workspace/tool/repro/run_build_in_container_workspace.sh \
     tool/repro/build_unsigned_android_appbundle.sh

--- a/tool/repro/build_unsigned_android_appbundle.sh
+++ b/tool/repro/build_unsigned_android_appbundle.sh
@@ -43,6 +43,7 @@ export RUSTUP_HOME="${RUSTUP_HOME:-/opt/rustup}"
 export CARGOKIT_RUST_TOOLCHAIN="${CARGOKIT_RUST_TOOLCHAIN:-1.90.0}"
 export SECLUSO_FLUTTER_VERBOSE="${SECLUSO_FLUTTER_VERBOSE:-0}"
 export SECLUSO_FDROID_BUILD="${SECLUSO_FDROID_BUILD:-0}"
+export SECLUSO_REPRO_GRADLE_JVMARGS="${SECLUSO_REPRO_GRADLE_JVMARGS:-}"
 export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-$SECLUSO_REPRO_MAX_WORKERS}"
 export CARGO_INCREMENTAL=0
 export SECLUSO_REPRO_CLEAN="${SECLUSO_REPRO_CLEAN:-0}"
@@ -94,6 +95,16 @@ cat > "$REPO_ROOT/android/local.properties" <<EOF
 sdk.dir=$ANDROID_HOME
 flutter.sdk=$FLUTTER_HOME
 EOF
+
+if [[ -n "$SECLUSO_REPRO_GRADLE_JVMARGS" ]]; then
+  log_step "Applying reproducible Gradle JVM args"
+  gradle_properties="$REPO_ROOT/android/gradle.properties"
+  if grep -q '^org\.gradle\.jvmargs=' "$gradle_properties"; then
+    sed -i "s|^org\.gradle\.jvmargs=.*|org.gradle.jvmargs=$SECLUSO_REPRO_GRADLE_JVMARGS|" "$gradle_properties"
+  else
+    printf '\norg.gradle.jvmargs=%s\n' "$SECLUSO_REPRO_GRADLE_JVMARGS" >> "$gradle_properties"
+  fi
+fi
 
 if [[ "$SECLUSO_REPRO_CLEAN" == "1" ]]; then
   log_step "Cleaning prior build outputs"

--- a/tool/repro/check_aab_reproducibility.sh
+++ b/tool/repro/check_aab_reproducibility.sh
@@ -81,6 +81,7 @@ copy_workspace() {
     -a
     --exclude '.git'
     --exclude 'android/local.properties'
+    --exclude 'android/app/src/main/jniLibs'
     --exclude '.secluso-repro-cache'
     --exclude 'build'
     --exclude 'ios/Pods'

--- a/tool/repro/check_bundletool_device_reproducibility.sh
+++ b/tool/repro/check_bundletool_device_reproducibility.sh
@@ -93,6 +93,7 @@ copy_workspace() {
     -a
     --exclude '.git'
     --exclude 'android/local.properties'
+    --exclude 'android/app/src/main/jniLibs'
     --exclude '.secluso-repro-cache'
     --exclude 'build'
     --exclude 'ios/Pods'

--- a/tool/repro/check_reproducibility.sh
+++ b/tool/repro/check_reproducibility.sh
@@ -81,6 +81,7 @@ copy_workspace() {
     -a
     --exclude '.git'
     --exclude 'android/local.properties'
+    --exclude 'android/app/src/main/jniLibs'
     --exclude '.secluso-repro-cache'
     --exclude 'build'
     --exclude 'ios/Pods'

--- a/tool/repro/run_build_in_container_workspace.sh
+++ b/tool/repro/run_build_in_container_workspace.sh
@@ -37,6 +37,7 @@ rsync_args=(
   --exclude '.git'
   --exclude '.secluso-repro-cache'
   --exclude 'android/local.properties'
+  --exclude 'android/app/src/main/jniLibs'
   --exclude 'build'
   --exclude 'ios/Pods'
 )
@@ -56,6 +57,7 @@ else
 fi
 
 rsync "${rsync_args[@]}" "$SOURCE_ROOT/" "$LOCAL_ROOT/"
+rm -rf "$LOCAL_ROOT/android/app/src/main/jniLibs"
 
 seed_local_cache_dir() {
   local relative_path="$1"


### PR DESCRIPTION
Before, we were introducing dirty local cache artifacts like built jniLibs in the local environment into the reproducible build flow. This is now automatically excluded. 

Additionally, there were leftover privastead references in rust_builder that are now fixed to say 'secluso'.

Additionally, a command was added to the README to articulate the exact command we use to build for releases.