### PR TITLE
Use Ubuntu archive snapshot to pin apt packages in Android reproducible builds

### DIFF
--- a/tool/repro/Dockerfile
+++ b/tool/repro/Dockerfile
@@ -1,6 +1,9 @@
-FROM ubuntu:24.04
+# Pinned ubuntu (index digest as of 2026-04-10)
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 ARG DEBIAN_FRONTEND=noninteractive
+# Ubuntu archive snapshot. Pins every apt package across builder rebuilds. 
+ARG UBUNTU_SNAPSHOT=20260501T000000Z
 ARG FLUTTER_REVISION=8defaa71a77c16e8547abdbfad2053ce3a6e2d5b
 ARG RUST_TOOLCHAIN=1.90.0
 ARG BUNDLETOOL_VERSION=1.18.2
@@ -26,21 +29,43 @@ ENV PUB_CACHE=/opt/pub-cache
 ENV RUSTUP_HOME=/opt/rustup
 ENV PATH=/opt/flutter/bin:/opt/android-sdk/cmdline-tools/latest/bin:/opt/android-sdk/platform-tools:/opt/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+# Bootstrap TLS trust from the base image's default (http, GPG-verified) apt sources first...
+# snapshot.ubuntu.com forces https and the minimal ubuntu base does not include ca-certificates.
+# ca-certificates is reinstalled from the pinned snapshot below, so the final installed version is still deterministic
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates; \
+    rm -rf /var/lib/apt/lists/*
+
+# Repoint apt at the pinned Ubuntu snapshot before any update/install
+RUN set -eux; \
+    : "${UBUNTU_SNAPSHOT:?missing UBUNTU_SNAPSHOT build arg}"; \
+    codename="$(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")"; \
+    snap="https://snapshot.ubuntu.com/ubuntu/${UBUNTU_SNAPSHOT}"; \
+    rm -f /etc/apt/sources.list.d/ubuntu.sources; \
+    { \
+    echo "deb ${snap} ${codename} main universe"; \
+    echo "deb ${snap} ${codename}-updates main universe"; \
+    echo "deb ${snap} ${codename}-security main universe"; \
+    } > /etc/apt/sources.list; \
+    printf 'Acquire::Check-Valid-Until "false";\nAcquire::Retries "8";\n' \
+    > /etc/apt/apt.conf.d/99snapshot
+
 RUN apt-get update \
     && apt-get install -y \
-        build-essential \
-        ca-certificates \
-        clang \
-        curl \
-        file \
-        git \
-        openjdk-17-jdk \
-        pkg-config \
-        python3 \
-        rsync \
-        unzip \
-        xz-utils \
-        zip \
+    build-essential \
+    ca-certificates \
+    clang \
+    curl \
+    file \
+    git \
+    openjdk-17-jdk \
+    pkg-config \
+    python3 \
+    rsync \
+    unzip \
+    xz-utils \
+    zip \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/android-sdk/cmdline-tools \
@@ -49,29 +74,29 @@ RUN mkdir -p /opt/android-sdk/cmdline-tools \
     && mv /opt/android-sdk/cmdline-tools/cmdline-tools /opt/android-sdk/cmdline-tools/latest \
     && yes | sdkmanager --licenses >/dev/null \
     && sdkmanager \
-        "build-tools;${ANDROID_BUILD_TOOLS}" \
-        "build-tools;${ANDROID_BUILD_TOOLS_COMPAT}" \
-        "cmake;${ANDROID_CMAKE}" \
-        "ndk;${ANDROID_NDK}" \
-        "platform-tools" \
-        "platforms;${ANDROID_PLATFORM}" \
-        "platforms;${ANDROID_PLATFORM_31}" \
-        "platforms;${ANDROID_PLATFORM_33}" \
-        "platforms;${ANDROID_PLATFORM_34}" \
-        "platforms;${ANDROID_PLATFORM_36}" \
+    "build-tools;${ANDROID_BUILD_TOOLS}" \
+    "build-tools;${ANDROID_BUILD_TOOLS_COMPAT}" \
+    "cmake;${ANDROID_CMAKE}" \
+    "ndk;${ANDROID_NDK}" \
+    "platform-tools" \
+    "platforms;${ANDROID_PLATFORM}" \
+    "platforms;${ANDROID_PLATFORM_31}" \
+    "platforms;${ANDROID_PLATFORM_33}" \
+    "platforms;${ANDROID_PLATFORM_34}" \
+    "platforms;${ANDROID_PLATFORM_36}" \
     && rm -f /tmp/android-tools.zip
 
 RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain "${RUST_TOOLCHAIN}" \
     && rustup target add \
-        --toolchain "${RUST_TOOLCHAIN}" \
-        aarch64-linux-android \
-        armv7-linux-androideabi \
-        i686-linux-android \
-        x86_64-linux-android
+    --toolchain "${RUST_TOOLCHAIN}" \
+    aarch64-linux-android \
+    armv7-linux-androideabi \
+    i686-linux-android \
+    x86_64-linux-android
 
 RUN curl -fsSL \
-      "https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar" \
-      -o /opt/bundletool.jar
+    "https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar" \
+    -o /opt/bundletool.jar
 
 RUN git clone https://github.com/flutter/flutter.git /opt/flutter \
     && cd /opt/flutter \

--- a/tool/repro/README.md
+++ b/tool/repro/README.md
@@ -60,6 +60,8 @@ When verifying reproducibility from a dirty local environment, use this command:
 env SECLUSO_REPRO_CLEAN=1 SECLUSO_REPRO_USE_HOST_CACHES=0 SECLUSO_REPRO_GRADLE_JVMARGS='-Xmx2G -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError' tool/repro/build_aab_with_docker.sh
 ```
 
+Note, when running from a Linux machine, it may need to be run using sudo. You may need to omit the gradle JVM arguments.
+
 - SECLUSO_REPRO_CLEAN=1 removes the copied workspace's Flutter, Android, and Rust build outputs before building. 
 - SECLUSO_REPRO_USE_HOST_CACHES=0 avoids mounting the host Gradle and Dart package caches into the container
 - SECLUSO_REPRO_GRADLE_JVMARGS=.. caps the Gradle and Kotlin daemon heaps. On Docker Desktop, the default android/gradle.properties heap can reserve too much memory during the clean native build and the Gradle daemon may disappear. 


### PR DESCRIPTION
Previously, there was a chance for drift in reproducible builds based on an underlying package fetched from apt getting a newer version than previously built that changed underlying structure in the build. Thus, an Ubuntu snapshot is now used to pin the versions for all packages fetched via apt in the builds for Android reproducible build.

https://github.com/secluso/core/pull/96 was also implemented for the complementary fix for the binaries and deploy tools.