### PR TITLE
Draft screens for phone-as-a-camera (camera-role) functionality

### DIFF
--- a/lib/keys.dart
+++ b/lib/keys.dart
@@ -21,6 +21,7 @@ class PrefKeys {
   static const serverAddr = "server_addr";
   static const serverUsername = "server_username";
   static const serverPassword = "server_password";
+  static const deviceRole = "device_role";
   static const relayConnectionKind = "relay_connection_kind";
   static const recordingMotionVideosPrefix = "recording_motion_videos_";
   static const lastRecordingTimestampPrefix = "last_recording_timestamp_";

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -965,32 +965,56 @@ class StartupRoleGate extends StatefulWidget {
 }
 
 class _StartupRoleGateState extends State<StartupRoleGate> {
-  late final Future<Widget> _initialPage = _loadInitialPage();
+  Widget? _page;
 
-  Future<Widget> _loadInitialPage() async {
+  @override
+  void initState() {
+    super.initState();
+    _loadInitialPage();
+  }
+
+  Future<void> _loadInitialPage() async {
     final prefs = await SharedPreferences.getInstance();
     final hasRelay = (prefs.getString(PrefKeys.serverAddr) ?? '').isNotEmpty;
     final role = prefs.getString(PrefKeys.deviceRole);
 
     if (hasRelay || role == _deviceRoleViewer || !cameraRoleSupported) {
-      return const AppShell();
+      _show(const AppShell());
+    } else if (role == _deviceRoleCamera) {
+      _show(_pairingPage());
+    } else {
+      _show(_roleSelectPage());
     }
-    if (role == _deviceRoleCamera) {
-      return const CameraRolePairingPage();
-    }
-    return RoleSelectPage(
-      onWatchCameras: _chooseViewerRole,
-      onBeCamera: _chooseCameraRole,
-    );
+  }
+
+  void _show(Widget page) {
+    if (!mounted) return;
+    setState(() => _page = page);
+  }
+
+  Widget _roleSelectPage() => RoleSelectPage(
+    onWatchCameras: _chooseViewerRole,
+    onBeCamera: _chooseCameraRole,
+  );
+
+  Widget _pairingPage() => CameraRolePairingPage(
+    onConnected: () => _show(_recordingPage()),
+    onClose: _returnToRoleSelect,
+  );
+
+  Widget _recordingPage() =>
+      CameraRoleRecordingPage(onUnpair: _returnToRoleSelect);
+
+  Future<void> _returnToRoleSelect() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(PrefKeys.deviceRole);
+    _show(_roleSelectPage());
   }
 
   Future<void> _chooseViewerRole() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(PrefKeys.deviceRole, _deviceRoleViewer);
-    if (!mounted) return;
-    await Navigator.of(context).pushReplacement(
-      MaterialPageRoute<void>(builder: (_) => const AppShell(initialIndex: 2)),
-    );
+    _show(const AppShell(initialIndex: 2));
   }
 
   Future<void> _chooseCameraRole() async {
@@ -1004,20 +1028,12 @@ class _StartupRoleGateState extends State<StartupRoleGate> {
     }
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(PrefKeys.deviceRole, _deviceRoleCamera);
-    if (!mounted) return;
-    await Navigator.of(context).pushReplacement(
-      MaterialPageRoute<void>(builder: (_) => const CameraRolePairingPage()),
-    );
+    _show(_pairingPage());
   }
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<Widget>(
-      future: _initialPage,
-      builder: (context, snapshot) {
-        return snapshot.data ?? const SplashScreen();
-      },
-    );
+    return _page ?? const SplashScreen();
   }
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,6 +42,8 @@ import 'package:secluso_flutter/constants.dart';
 import 'package:secluso_flutter/ui/secluso_surfaces.dart';
 import 'package:secluso_flutter/ui/font_licenses.dart';
 import 'package:secluso_flutter/ui/secluso_theme.dart';
+import 'package:secluso_flutter/routes/camera-role/camera_role_pages.dart';
+import 'package:secluso_flutter/routes/system_shell_page.dart';
 import 'dart:isolate';
 
 final ReceivePort _mainReceivePort = ReceivePort();
@@ -952,6 +954,72 @@ Future<void> _checkForUpdates() async {
 
 final RouteObserver<ModalRoute<void>> routeObserver =
     RouteObserver<ModalRoute<void>>();
+const String _deviceRoleViewer = 'viewer';
+const String _deviceRoleCamera = 'camera';
+
+class StartupRoleGate extends StatefulWidget {
+  const StartupRoleGate({super.key});
+
+  @override
+  State<StartupRoleGate> createState() => _StartupRoleGateState();
+}
+
+class _StartupRoleGateState extends State<StartupRoleGate> {
+  late final Future<Widget> _initialPage = _loadInitialPage();
+
+  Future<Widget> _loadInitialPage() async {
+    final prefs = await SharedPreferences.getInstance();
+    final hasRelay = (prefs.getString(PrefKeys.serverAddr) ?? '').isNotEmpty;
+    final role = prefs.getString(PrefKeys.deviceRole);
+
+    if (hasRelay || role == _deviceRoleViewer || !cameraRoleSupported) {
+      return const AppShell();
+    }
+    if (role == _deviceRoleCamera) {
+      return const CameraRolePairingPage();
+    }
+    return RoleSelectPage(
+      onWatchCameras: _chooseViewerRole,
+      onBeCamera: _chooseCameraRole,
+    );
+  }
+
+  Future<void> _chooseViewerRole() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(PrefKeys.deviceRole, _deviceRoleViewer);
+    if (!mounted) return;
+    await Navigator.of(context).pushReplacement(
+      MaterialPageRoute<void>(builder: (_) => const AppShell(initialIndex: 2)),
+    );
+  }
+
+  Future<void> _chooseCameraRole() async {
+    if (!cameraRoleSupported) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Camera role is only supported on Android.'),
+        ),
+      );
+      return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(PrefKeys.deviceRole, _deviceRoleCamera);
+    if (!mounted) return;
+    await Navigator.of(context).pushReplacement(
+      MaterialPageRoute<void>(builder: (_) => const CameraRolePairingPage()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Widget>(
+      future: _initialPage,
+      builder: (context, snapshot) {
+        return snapshot.data ?? const SplashScreen();
+      },
+    );
+  }
+}
 
 class MyApp extends StatefulWidget {
   const MyApp({super.key, required this.isReady, this.initError});
@@ -1042,8 +1110,8 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
                               ) ??
                               (_launchDesignLab
                                   ? const DesignLabPage()
-                                  : const AppShell()))
-                      : const AppShell(),
+                                  : const StartupRoleGate()))
+                      : const StartupRoleGate(),
             )
             : SplashScreen(errorMessage: widget.initError);
 

--- a/lib/routes/camera-role/camera_role_pages.dart
+++ b/lib/routes/camera-role/camera_role_pages.dart
@@ -1,0 +1,6 @@
+//! SPDX-License-Identifier: GPL-3.0-or-later
+
+// Export out necessary stuff to be externally used.
+export 'pages/camera_role_pairing_page.dart';
+export 'pages/camera_role_recording_page.dart';
+export 'platform.dart';

--- a/lib/routes/camera-role/pages/camera_role_pairing_page.dart
+++ b/lib/routes/camera-role/pages/camera_role_pairing_page.dart
@@ -11,10 +11,13 @@ import 'package:secluso_flutter/ui/google_fonts.dart';
 
 /// Shows the camera QR + live Bluetooth advertising state, waiting for the primary app to connect.
 class CameraRolePairingPage extends StatelessWidget {
-  const CameraRolePairingPage({super.key, this.onConnected});
+  const CameraRolePairingPage({super.key, this.onConnected, this.onClose});
 
   /// In production this fires automatically when the MLS handshake completes.
   final VoidCallback? onConnected;
+
+  /// Invoked when the user dismisses pairing via the close button.
+  final VoidCallback? onClose;
 
   // A representative camera-QR payload for dummy testing until we get to swap this out
   static const _samplePayload =
@@ -41,7 +44,8 @@ class CameraRolePairingPage extends StatelessWidget {
                         color: Colors.white,
                         size: sz(22),
                       ),
-                      onPressed: () => Navigator.of(context).maybePop(),
+                      onPressed:
+                          onClose ?? () => Navigator.of(context).maybePop(),
                     ),
                   ),
                   SizedBox(height: sz(8)),

--- a/lib/routes/camera-role/pages/camera_role_pairing_page.dart
+++ b/lib/routes/camera-role/pages/camera_role_pairing_page.dart
@@ -1,0 +1,113 @@
+//! SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Allow another phone to pair to this one; act in the role of Bluetooth advertising.
+
+import 'package:flutter/material.dart';
+import 'package:secluso_flutter/routes/camera-role/pages/camera_role_recording_page.dart';
+import 'package:secluso_flutter/routes/camera-role/theme.dart';
+import 'package:secluso_flutter/routes/camera-role/widgets/qr_card.dart';
+import 'package:secluso_flutter/routes/camera-role/widgets/shared_widgets.dart';
+import 'package:secluso_flutter/ui/google_fonts.dart';
+
+/// Shows the camera QR + live Bluetooth advertising state, waiting for the primary app to connect.
+class CameraRolePairingPage extends StatelessWidget {
+  const CameraRolePairingPage({super.key, this.onConnected});
+
+  /// In production this fires automatically when the MLS handshake completes.
+  final VoidCallback? onConnected;
+
+  // A representative camera-QR payload for dummy testing until we get to swap this out
+  static const _samplePayload =
+      '{"v":"v1.2","cs":"k7Qm2Zr9Yx1Bv3Nw8Lp5Td0Hs6Jf4Gc","wp":"a1b2c3d4"}';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: cameraRoleBg,
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final s = cameraRoleFlowScale(constraints);
+            double sz(double v) => v * s;
+            return SingleChildScrollView(
+              padding: EdgeInsets.fromLTRB(sz(24), sz(8), sz(24), sz(24)),
+              child: Column(
+                children: [
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: IconButton(
+                      icon: Icon(
+                        Icons.close_rounded,
+                        color: Colors.white,
+                        size: sz(22),
+                      ),
+                      onPressed: () => Navigator.of(context).maybePop(),
+                    ),
+                  ),
+                  SizedBox(height: sz(8)),
+                  CameraRoleFlowHeading(
+                    scale: s,
+                    title: 'Scan from your main phone',
+                    body:
+                        'On the phone you watch your cameras from, add a '
+                        'camera and scan this code.',
+                  ),
+                  SizedBox(height: sz(28)),
+                  QrCard(scale: s, payload: _samplePayload),
+                  SizedBox(height: sz(24)),
+                  CameraRoleTintedCard(
+                    scale: s,
+                    accent: cameraRoleBlue,
+                    icon: Icons.bluetooth_rounded,
+                    title: 'Advertising over Bluetooth',
+                    body:
+                        'Keep both phones nearby and unlocked. Pairing '
+                        'completes automatically once it connects.',
+                  ),
+                  SizedBox(height: sz(16)),
+                  CameraRoleInfoCard(
+                    scale: s,
+                    rows: [
+                      CameraRoleInfoRow(
+                        scale: s,
+                        label: 'Status',
+                        value: 'Advertising',
+                        valueColor: cameraRoleAmber,
+                        leading: cameraRoleDot(sz(6), cameraRoleAmber),
+                        showDivider: false,
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: sz(18)),
+                  TextButton.icon(
+                    onPressed:
+                        onConnected ??
+                        () => Navigator.of(context).pushReplacement(
+                          MaterialPageRoute<void>(
+                            builder: (_) => const CameraRoleRecordingPage(),
+                          ),
+                        ),
+                    style: TextButton.styleFrom(
+                      foregroundColor: cameraRoleWhite20,
+                    ),
+                    icon: Icon(
+                      Icons.check_circle_outline_rounded,
+                      size: sz(15),
+                    ),
+                    label: Text(
+                      'Simulate "camera connected"',
+                      style: GoogleFonts.inter(
+                        fontSize: sz(11),
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/camera-role/pages/camera_role_recording_page.dart
+++ b/lib/routes/camera-role/pages/camera_role_recording_page.dart
@@ -7,7 +7,10 @@ import 'package:secluso_flutter/routes/camera-role/theme.dart';
 import 'package:secluso_flutter/routes/camera-role/widgets/shared_widgets.dart';
 
 class CameraRoleRecordingPage extends StatefulWidget {
-  const CameraRoleRecordingPage({super.key});
+  const CameraRoleRecordingPage({super.key, this.onUnpair});
+
+  /// Invoked once the user confirms stopping and unpairing.
+  final VoidCallback? onUnpair;
 
   @override
   State<CameraRoleRecordingPage> createState() =>
@@ -20,19 +23,45 @@ class _CameraRoleRecordingPageState extends State<CameraRoleRecordingPage> {
       context: context,
       builder: (dialogContext) {
         return AlertDialog(
-          title: const Text('Are you sure?'),
+          backgroundColor: const Color(0xFF161616),
+          titleTextStyle: const TextStyle(
+            color: Colors.white,
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+          ),
+          contentTextStyle: const TextStyle(
+            color: cameraRoleWhite40,
+            fontSize: 14,
+            height: 1.4,
+          ),
+          title: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Expanded(child: Text('Stop and unpair?')),
+              IconButton(
+                onPressed: () => Navigator.of(dialogContext).pop(false),
+                icon: const Icon(Icons.close_rounded),
+                color: cameraRoleWhite40,
+                iconSize: 20,
+                visualDensity: VisualDensity.compact,
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+                tooltip: 'Cancel',
+              ),
+            ],
+          ),
           content: const Text(
-            'This will stop recording and unpair the camera role from this phone.',
+            'This will stop recording and unpair the camera role from this '
+            'phone.',
           ),
           actions: [
             FilledButton(
-              onPressed: () => Navigator.of(dialogContext).pop(false),
-              child: const Text('Cancel'),
-            ),
-            Padding(padding: EdgeInsetsGeometry.all(5)),
-            FilledButton(
               onPressed: () => Navigator.of(dialogContext).pop(true),
-              child: const Text('Unpair the camera.'),
+              style: FilledButton.styleFrom(
+                backgroundColor: cameraRoleDanger,
+                foregroundColor: cameraRoleBg,
+              ),
+              child: const Text('Unpair'),
             ),
           ],
         );
@@ -42,7 +71,7 @@ class _CameraRoleRecordingPageState extends State<CameraRoleRecordingPage> {
     if (shouldStop != true || !mounted) {
       return;
     }
-    Navigator.of(context).popUntil((route) => route.isFirst);
+    widget.onUnpair?.call();
   }
 
   @override

--- a/lib/routes/camera-role/pages/camera_role_recording_page.dart
+++ b/lib/routes/camera-role/pages/camera_role_recording_page.dart
@@ -1,0 +1,142 @@
+//! SPDX-License-Identifier: GPL-3.0-or-later
+//
+// We've already paired. Now we just show the current state of what this "camera" (the disposable phone) is doing.
+
+import 'package:flutter/material.dart';
+import 'package:secluso_flutter/routes/camera-role/theme.dart';
+import 'package:secluso_flutter/routes/camera-role/widgets/shared_widgets.dart';
+
+class CameraRoleRecordingPage extends StatefulWidget {
+  const CameraRoleRecordingPage({super.key});
+
+  @override
+  State<CameraRoleRecordingPage> createState() =>
+      _CameraRoleRecordingPageState();
+}
+
+class _CameraRoleRecordingPageState extends State<CameraRoleRecordingPage> {
+  Future<void> _confirmStopAndUnpair() async {
+    final shouldStop = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('Are you sure?'),
+          content: const Text(
+            'This will stop recording and unpair the camera role from this phone.',
+          ),
+          actions: [
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('Cancel'),
+            ),
+            Padding(padding: EdgeInsetsGeometry.all(5)),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('Unpair the camera.'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (shouldStop != true || !mounted) {
+      return;
+    }
+    Navigator.of(context).popUntil((route) => route.isFirst);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: cameraRoleBg,
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final s = cameraRoleFlowScale(constraints);
+            double sz(double v) => v * s;
+            return SingleChildScrollView(
+              padding: EdgeInsets.fromLTRB(sz(24), sz(12), sz(24), sz(24)),
+              child: Column(
+                children: [
+                  Row(
+                    children: [
+                      const Spacer(),
+                      IconButton(
+                        tooltip: 'Stop and unpair',
+                        icon: Icon(
+                          Icons.power_settings_new_rounded,
+                          color: cameraRoleDanger,
+                          size: sz(22),
+                        ),
+                        onPressed: _confirmStopAndUnpair,
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: sz(20)),
+                  CameraRoleRingOrb(
+                    scale: s,
+                    icon: Icons.videocam_rounded,
+                    pulse: true,
+                  ),
+                  SizedBox(height: sz(32)),
+                  CameraRoleFlowHeading(
+                    scale: s,
+                    title: 'Recording',
+                    body:
+                        'Camera and microphone are streaming,\n'
+                        'encrypted, to your relay.',
+                  ),
+                  SizedBox(height: sz(32)),
+                  CameraRoleInfoCard(
+                    scale: s,
+                    rows: [
+                      CameraRoleInfoRow(
+                        scale: s,
+                        label: 'Status',
+                        value: 'Recording',
+                        valueColor: cameraRoleEmerald,
+                        leading: cameraRoleDot(sz(6), cameraRoleEmerald),
+                      ),
+                      CameraRoleInfoRow(
+                        scale: s,
+                        label: 'Encryption',
+                        value: 'E2EE Active',
+                        leading: Icon(
+                          Icons.lock_outline_rounded,
+                          size: sz(11),
+                          color: cameraRoleBlue,
+                        ),
+                      ),
+                      CameraRoleInfoRow(
+                        scale: s,
+                        label: 'Uploaded',
+                        value: '1.2 MB',
+                        mono: true,
+                      ),
+                      CameraRoleInfoRow(
+                        scale: s,
+                        label: 'Pending',
+                        value: '0 segments',
+                        mono: true,
+                        showDivider: false,
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: sz(16)),
+                  CameraRoleTintedCard(
+                    scale: s,
+                    accent: cameraRoleEmerald,
+                    icon: Icons.battery_charging_full_rounded,
+                    title: 'Leave it plugged in',
+                    body:
+                        'The screen can stay dark. Secluso keeps recording in the background.',
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/camera-role/platform.dart
+++ b/lib/routes/camera-role/platform.dart
@@ -1,0 +1,6 @@
+//! SPDX-License-Identifier: GPL-3.0-or-later
+
+import 'dart:io' show Platform;
+
+/// The camera role is Android-only. iOS phones are not cheap; doesn't make sense to prioritize support for them yet.
+bool get cameraRoleSupported => Platform.isAndroid;

--- a/lib/routes/camera-role/theme.dart
+++ b/lib/routes/camera-role/theme.dart
@@ -1,0 +1,22 @@
+//! SPDX-License-Identifier: GPL-3.0-or-later
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+const cameraRoleBg = Color(0xFF050505);
+const cameraRoleEmerald = Color(0xFF10B981);
+const cameraRoleBlue = Color(0xFF8BB3EE);
+const cameraRoleAmber = Color(0xFFF0C08A);
+const cameraRoleDanger = Color(0xFFF29BA0);
+const cameraRoleWhite40 = Color(0x66FFFFFF);
+const cameraRoleWhite20 = Color(0x33FFFFFF);
+
+double cameraRoleFlowScale(BoxConstraints c) =>
+    math.min(c.maxWidth / 290, c.maxHeight / 652);
+
+Widget cameraRoleDot(double size, Color color) => Container(
+  width: size,
+  height: size,
+  decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+);

--- a/lib/routes/camera-role/widgets/qr_card.dart
+++ b/lib/routes/camera-role/widgets/qr_card.dart
@@ -1,0 +1,58 @@
+//! SPDX-License-Identifier: GPL-3.0-or-later
+
+import 'package:flutter/material.dart';
+import 'package:flutter_zxing/flutter_zxing.dart' as zxing;
+
+class QrCard extends StatelessWidget {
+  const QrCard({required this.scale, required this.payload, super.key});
+
+  static const _qrPixelSize = 256;
+
+  final double scale;
+  final String payload;
+
+  @override
+  Widget build(BuildContext context) {
+    final encoded = zxing.zx.encodeBarcode(
+      contents: payload,
+      params: zxing.EncodeParams(
+        format: zxing.Format.qrCode,
+        width: _qrPixelSize,
+        height: _qrPixelSize,
+        margin: 8,
+        eccLevel: zxing.EccLevel.quartile,
+      ),
+    );
+
+    return Container(
+      padding: EdgeInsets.all(scale * 18),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(scale * 20),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.4),
+            blurRadius: scale * 28,
+            offset: Offset(0, scale * 14),
+          ),
+        ],
+      ),
+      child: SizedBox(
+        width: scale * 200,
+        height: scale * 200,
+        child:
+            encoded.isValid && encoded.data != null
+                ? Image.memory(
+                  zxing.pngFromBytes(encoded.data!, _qrPixelSize, _qrPixelSize),
+                  filterQuality: FilterQuality.none,
+                  gaplessPlayback: true,
+                )
+                : Icon(
+                  Icons.qr_code_2_rounded,
+                  color: Colors.black.withValues(alpha: 0.25),
+                  size: scale * 64,
+                ),
+      ),
+    );
+  }
+}

--- a/lib/routes/camera-role/widgets/shared_widgets.dart
+++ b/lib/routes/camera-role/widgets/shared_widgets.dart
@@ -1,0 +1,308 @@
+//! SPDX-License-Identifier: GPL-3.0-or-later
+
+import 'package:flutter/material.dart';
+import 'package:secluso_flutter/routes/camera-role/theme.dart';
+import 'package:secluso_flutter/ui/google_fonts.dart';
+
+class CameraRoleFlowHeading extends StatelessWidget {
+  const CameraRoleFlowHeading({
+    required this.scale,
+    required this.title,
+    required this.body,
+    super.key,
+  });
+
+  final double scale;
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          title,
+          textAlign: TextAlign.center,
+          style: GoogleFonts.inter(
+            color: Colors.white,
+            fontSize: scale * 20,
+            fontWeight: FontWeight.w600,
+            height: 30 / 20,
+            letterSpacing: -0.3,
+          ),
+        ),
+        SizedBox(height: scale * 12),
+        SizedBox(
+          width: scale * 240,
+          child: Text(
+            body,
+            textAlign: TextAlign.center,
+            style: GoogleFonts.inter(
+              color: cameraRoleWhite40,
+              fontSize: scale * 12,
+              fontWeight: FontWeight.w400,
+              height: 19.5 / 12,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class CameraRoleRingOrb extends StatefulWidget {
+  const CameraRoleRingOrb({
+    required this.scale,
+    required this.icon,
+    this.pulse = false,
+    super.key,
+  });
+
+  final double scale;
+  final IconData icon;
+  final bool pulse;
+
+  @override
+  State<CameraRoleRingOrb> createState() => _CameraRoleRingOrbState();
+}
+
+class _CameraRoleRingOrbState extends State<CameraRoleRingOrb>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _c = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 2400),
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.pulse) _c.repeat();
+  }
+
+  @override
+  void dispose() {
+    _c.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    double sz(double v) => v * widget.scale;
+    Widget ring(double d, Color color) => Container(
+      width: d,
+      height: d,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(color: color, width: sz(2)),
+      ),
+    );
+    final orb = SizedBox(
+      width: sz(80),
+      height: sz(80),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          ring(sz(80), const Color(0x4D10B981)),
+          ring(sz(64), const Color(0x3310B981)),
+          Container(
+            width: sz(56),
+            height: sz(56),
+            decoration: BoxDecoration(
+              color: cameraRoleEmerald,
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(color: const Color(0x6622C55E), blurRadius: sz(24)),
+              ],
+            ),
+            child: Icon(widget.icon, color: Colors.white, size: sz(26)),
+          ),
+        ],
+      ),
+    );
+    if (!widget.pulse) return orb;
+    return SizedBox(
+      width: sz(80) * 1.8,
+      height: sz(80) * 1.8,
+      child: AnimatedBuilder(
+        animation: _c,
+        builder: (context, _) {
+          final t = _c.value;
+          return Stack(
+            alignment: Alignment.center,
+            children: [
+              Container(
+                width: sz(80) * (1 + t * 0.8),
+                height: sz(80) * (1 + t * 0.8),
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: cameraRoleEmerald.withValues(alpha: (1 - t) * 0.22),
+                    width: sz(1.5),
+                  ),
+                ),
+              ),
+              orb,
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+class CameraRoleInfoCard extends StatelessWidget {
+  const CameraRoleInfoCard({
+    required this.scale,
+    required this.rows,
+    super.key,
+  });
+
+  final double scale;
+  final List<Widget> rows;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.03),
+        borderRadius: BorderRadius.circular(scale * 12),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.05)),
+      ),
+      child: Column(children: rows),
+    );
+  }
+}
+
+class CameraRoleInfoRow extends StatelessWidget {
+  const CameraRoleInfoRow({
+    required this.scale,
+    required this.label,
+    required this.value,
+    this.leading,
+    this.valueColor = Colors.white,
+    this.mono = false,
+    this.showDivider = true,
+    super.key,
+  });
+
+  final double scale;
+  final String label;
+  final String value;
+  final Widget? leading;
+  final Color valueColor;
+  final bool mono;
+  final bool showDivider;
+
+  @override
+  Widget build(BuildContext context) {
+    final base = mono ? GoogleFonts.robotoMono() : GoogleFonts.inter();
+    return Container(
+      height: scale * 47,
+      padding: EdgeInsets.symmetric(horizontal: scale * 14),
+      decoration: BoxDecoration(
+        border:
+            showDivider
+                ? Border(
+                  bottom: BorderSide(
+                    color: Colors.white.withValues(alpha: 0.04),
+                  ),
+                )
+                : null,
+      ),
+      child: Row(
+        children: [
+          Text(
+            label,
+            style: GoogleFonts.inter(
+              color: cameraRoleWhite40,
+              fontSize: scale * 11,
+              fontWeight: FontWeight.w400,
+              height: 16.5 / 11,
+            ),
+          ),
+          const Spacer(),
+          if (leading != null) ...[leading!, SizedBox(width: scale * 6)],
+          Flexible(
+            child: Text(
+              value,
+              overflow: TextOverflow.ellipsis,
+              style: base.copyWith(
+                color: valueColor,
+                fontSize: scale * 12,
+                fontWeight: FontWeight.w500,
+                height: 18 / 12,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class CameraRoleTintedCard extends StatelessWidget {
+  const CameraRoleTintedCard({
+    required this.scale,
+    required this.accent,
+    required this.icon,
+    required this.title,
+    required this.body,
+    super.key,
+  });
+
+  final double scale;
+  final Color accent;
+  final IconData icon;
+  final String title;
+  final String body;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.06),
+        borderRadius: BorderRadius.circular(scale * 12),
+        border: Border.all(color: accent.withValues(alpha: 0.15)),
+      ),
+      padding: EdgeInsets.all(scale * 16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: EdgeInsets.only(top: scale * 2),
+            child: Icon(icon, color: accent, size: scale * 16),
+          ),
+          SizedBox(width: scale * 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: GoogleFonts.inter(
+                    color: accent,
+                    fontSize: scale * 11,
+                    fontWeight: FontWeight.w600,
+                    height: 16.5 / 11,
+                  ),
+                ),
+                SizedBox(height: scale * 8),
+                Text(
+                  body,
+                  style: GoogleFonts.inter(
+                    color: cameraRoleWhite40,
+                    fontSize: scale * 10,
+                    fontWeight: FontWeight.w400,
+                    height: 16.25 / 10,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/routes/design_lab_page.dart
+++ b/lib/routes/design_lab_page.dart
@@ -20,6 +20,8 @@ import 'package:secluso_flutter/routes/camera/view_camera.dart';
 import 'package:secluso_flutter/routes/camera/view_livestream.dart';
 import 'package:secluso_flutter/routes/camera/view_video.dart';
 import 'package:secluso_flutter/routes/server_page.dart';
+import 'package:secluso_flutter/routes/system_shell_page.dart';
+import 'package:secluso_flutter/routes/camera-role/camera_role_pages.dart';
 import 'package:secluso_flutter/routes/settings_page.dart' as app_settings;
 import 'package:secluso_flutter/ui/secluso_preview_assets.dart';
 import 'package:secluso_flutter/routes/theme_provider.dart';
@@ -483,6 +485,23 @@ Widget? designLabTargetPage(String target, {String themeName = 'dark'}) {
         previewServerAddr: reviewSession.relayAddress,
         previewCameraNames: reviewSession.cameraNames,
       );
+    case 'role_select':
+      return Builder(
+        builder:
+            (context) => RoleSelectPage(
+              onWatchCameras: () {},
+              onBeCamera:
+                  () => Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const CameraRolePairingPage(),
+                    ),
+                  ),
+            ),
+      );
+    case 'camera_role_pairing':
+      return const CameraRolePairingPage();
+    case 'camera_role_recording':
+      return const CameraRoleRecordingPage();
     case 'system_unpaired':
       return const AppShell(
         initialIndex: 2,

--- a/lib/routes/system_shell_page.dart
+++ b/lib/routes/system_shell_page.dart
@@ -4,6 +4,181 @@ import 'package:flutter/material.dart';
 import 'package:secluso_flutter/ui/google_fonts.dart';
 import 'package:secluso_flutter/ui/secluso_shell_ui.dart';
 
+/// The very first screen on a fresh install: pick what this phone's job is.
+///
+/// Choosing "Watch my cameras" continues into what the app used to be, pick a relay, then add a camera...
+/// Choosing "Be a camera" enters the camera role flow (acts on its own as a camera)
+
+class RoleSelectPage extends StatelessWidget {
+  const RoleSelectPage({
+    super.key,
+    required this.onWatchCameras,
+    required this.onBeCamera,
+  });
+
+  final VoidCallback onWatchCameras;
+  final VoidCallback onBeCamera;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final metrics = _SystemShellUnpairedMetrics.forWidth(
+          constraints.maxWidth,
+        );
+        return Scaffold(
+          backgroundColor: const Color(0xFF050505),
+          body: SafeArea(
+            child: ListView(
+              physics: const BouncingScrollPhysics(),
+              padding: EdgeInsets.fromLTRB(
+                0,
+                metrics.topPadding,
+                0,
+                metrics.bottomPadding,
+              ),
+              children: [
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: metrics.pageInset),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Secluso',
+                        style: shellTitleStyle(
+                          context,
+                          fontSize: metrics.titleSize,
+                          designLetterSpacing: 0.55,
+                          color: Colors.white,
+                        ),
+                      ),
+                      SizedBox(height: metrics.subtitleTopGap),
+                      Text(
+                        "LET'S GET YOU SET UP",
+                        style: GoogleFonts.inter(
+                          color: Colors.white.withValues(alpha: 0.4),
+                          fontSize: metrics.subtitleSize,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: metrics.subtitleSize * 0.18,
+                          height: 16.5 / 11,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                SizedBox(height: metrics.headerToCardGap),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: metrics.railInset),
+                  child: _RoleSetupCard(
+                    metrics: metrics,
+                    onWatchCameras: onWatchCameras,
+                    onBeCamera: onBeCamera,
+                  ),
+                ),
+                SizedBox(height: metrics.cardGap),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: metrics.railInset),
+                  child: _SystemDarkSecurityCard(metrics: metrics),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _RoleSetupCard extends StatelessWidget {
+  const _RoleSetupCard({
+    required this.metrics,
+    required this.onWatchCameras,
+    required this.onBeCamera,
+  });
+
+  final _SystemShellUnpairedMetrics metrics;
+  final VoidCallback onWatchCameras;
+  final VoidCallback onBeCamera;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      foregroundPainter: ShellTopAccentBorderPainter(
+        color: const Color(0xFF8BB3EE),
+        strokeWidth: metrics.setupAccentStrokeWidth,
+        radius: metrics.cardRadius,
+        revealHeight: metrics.cardRadius * 0.92,
+      ),
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.03),
+          borderRadius: BorderRadius.circular(metrics.cardRadius),
+          border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+        ),
+        padding: EdgeInsets.all(metrics.cardInset),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              "What's this phone's job?",
+              style: GoogleFonts.inter(
+                color: Colors.white,
+                fontSize: metrics.setupTitleSize,
+                fontWeight: FontWeight.w600,
+                height: 24 / 16,
+              ),
+            ),
+            SizedBox(height: metrics.setupTitleGap),
+            Text(
+              'Pick a role for this device.\nYou can change it later.',
+              style: GoogleFonts.inter(
+                color: const Color(0xFF6D7077),
+                fontSize: metrics.setupBodySize,
+                fontWeight: FontWeight.w400,
+                height: 17.88 / 11,
+              ),
+            ),
+            SizedBox(height: metrics.setupBodyGap),
+            _SystemDarkSetupOption(
+              metrics: metrics,
+              title: 'Watch my cameras',
+              subtitle: 'See live and saved video.\nConnects to your relay.',
+              icon: const SizedBox(
+                width: 16,
+                height: 16,
+                child: CustomPaint(
+                  painter: _RoleViewerIconPainter(Color(0xFF8BB3EE)),
+                ),
+              ),
+              iconBackground: const Color(0x338BB3EE),
+              backgroundColor: const Color(0x1A8BB3EE),
+              borderColor: const Color(0x338BB3EE),
+              onTap: onWatchCameras,
+            ),
+            SizedBox(height: metrics.optionGap),
+            _SystemDarkSetupOption(
+              metrics: metrics,
+              title: 'Be a camera',
+              subtitle: 'Leave a spare phone recording.\nPairs over Bluetooth.',
+              icon: const SizedBox(
+                width: 16,
+                height: 16,
+                child: CustomPaint(
+                  painter: _RoleCameraIconPainter(Color(0xFF8BB3EE)),
+                ),
+              ),
+              iconBackground: const Color(0x1A8BB3EE),
+              backgroundColor: Colors.white.withValues(alpha: 0.04),
+              borderColor: Colors.white.withValues(alpha: 0.08),
+              onTap: onBeCamera,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class SystemShellUnpairedPage extends StatelessWidget {
   const SystemShellUnpairedPage({
     super.key,
@@ -671,6 +846,110 @@ class _SystemSelfHostedIconPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant _SystemSelfHostedIconPainter oldDelegate) =>
+      oldDelegate.color != color;
+}
+
+/// Role icon: a monitor with a play glyph ("watch my cameras").
+class _RoleViewerIconPainter extends CustomPainter {
+  const _RoleViewerIconPainter(this.color);
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    double x(double u) => size.width * (u / 16);
+    double y(double u) => size.height * (u / 16);
+    final stroke =
+        Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = size.width * (1.33333 / 16)
+          ..color = color
+          ..strokeCap = StrokeCap.round
+          ..strokeJoin = StrokeJoin.round
+          ..isAntiAlias = true;
+    // Screen frame.
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromLTWH(x(2), y(2.6667), x(12), y(8)),
+        Radius.circular(x(1.3333)),
+      ),
+      stroke,
+    );
+    // Stand.
+    canvas.drawLine(Offset(x(8), y(10.6667)), Offset(x(8), y(12.8)), stroke);
+    canvas.drawLine(
+      Offset(x(5.3333), y(12.8)),
+      Offset(x(10.6667), y(12.8)),
+      stroke,
+    );
+    // Play glyph.
+    final fill =
+        Paint()
+          ..style = PaintingStyle.fill
+          ..color = color
+          ..isAntiAlias = true;
+    final play =
+        Path()
+          ..moveTo(x(6.9), y(4.9))
+          ..lineTo(x(6.9), y(8.4))
+          ..lineTo(x(9.9), y(6.65))
+          ..close();
+    canvas.drawPath(play, fill);
+  }
+
+  @override
+  bool shouldRepaint(covariant _RoleViewerIconPainter oldDelegate) =>
+      oldDelegate.color != color;
+}
+
+/// Role icon: a camcorder with a record dot ("be a camera").
+class _RoleCameraIconPainter extends CustomPainter {
+  const _RoleCameraIconPainter(this.color);
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    double x(double u) => size.width * (u / 16);
+    double y(double u) => size.height * (u / 16);
+    final stroke =
+        Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = size.width * (1.33333 / 16)
+          ..color = color
+          ..strokeCap = StrokeCap.round
+          ..strokeJoin = StrokeJoin.round
+          ..isAntiAlias = true;
+    // Body.
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromLTWH(x(2), y(4.6667), x(8), y(6.6667)),
+        Radius.circular(x(1.3333)),
+      ),
+      stroke,
+    );
+    // Lens barrel.
+    final lens =
+        Path()
+          ..moveTo(x(10), y(7))
+          ..lineTo(x(13.6667), y(5))
+          ..lineTo(x(13.6667), y(11))
+          ..lineTo(x(10), y(9))
+          ..close();
+    canvas.drawPath(lens, stroke);
+    // Record dot.
+    canvas.drawCircle(
+      Offset(x(5), y(8)),
+      x(1),
+      Paint()
+        ..style = PaintingStyle.fill
+        ..color = color
+        ..isAntiAlias = true,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _RoleCameraIconPainter oldDelegate) =>
       oldDelegate.color != color;
 }
 


### PR DESCRIPTION
Implements the UI for the screens that were discussed in the issue below. There's no real functionality in here. The screens are added with dummy camera QR codes and dummy functionality. Needs to be implemented later.

<img width="210" height="450" alt="Screenshot 2026-06-28 at 11 30 10 AM" src="https://github.com/user-attachments/assets/c5a855d8-adbd-4aa4-b8bc-38a91acbf379" />
<img width="210" height="450" alt="Screenshot 2026-06-28 at 11 30 18 AM" src="https://github.com/user-attachments/assets/c11b324f-1274-4b75-8766-87e6e021a5ad" />
<img width="210" height="450" alt="Screenshot 2026-06-28 at 11 30 17 AM" src="https://github.com/user-attachments/assets/a819b4d2-f883-428e-addb-4dd2cb64234a" />

Fixes https://github.com/secluso/mobile_client/issues/91